### PR TITLE
sendEvent에 대한 메모리 라이프 사이클을 확보했습니다.

### DIFF
--- a/Echo_Server/Ehco_Client/Client.cpp
+++ b/Echo_Server/Ehco_Client/Client.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include <set>
 
 DWORD WINAPI EchoThreadMain();
 
@@ -18,12 +19,12 @@ int main() {
 
 	std::thread worker(EchoThreadMain);
 
-
-	for (int i = 0; i < 10; i++) {
+	std::set<std::shared_ptr<Session>> sessions;
+	for (int i = 0; i < 100; i++) {
 		std::shared_ptr<Session> session = std::make_shared<Session>(iocpHandle);
 		session->Connect("127.0.0.1",7777);
+		sessions.insert(session);
 	}
-
 
 	worker.join();
 }
@@ -36,7 +37,7 @@ DWORD WINAPI EchoThreadMain() {
 		ULONG_PTR key = 0;
 
 		if (true == ::GetQueuedCompletionStatus(iocpHandle, &bytesTransffered,&key, reinterpret_cast<LPOVERLAPPED*>(&ioEvent), INFINITE)) {
-			std::shared_ptr<IocpObject> iocpObject = ioEvent->owner;
+			auto iocpObject = ioEvent->owner;
 			iocpObject->OnExecute(ioEvent);
 		}
 		else {

--- a/Echo_Server/Network/Session.h
+++ b/Echo_Server/Network/Session.h
@@ -42,7 +42,9 @@ private:
 
 	IoEvent _connectEvent;
 	IoEvent _recvEvent;
+	IoEvent _sendEvent;
 	char* _recvBuffer;
+
 
 	LPFN_CONNECTEX ConnectEx;
 };


### PR DESCRIPTION
또한 client에서 생성한 session도 명시적 라이프 사이클을 가지도록 했습니다

제가 수정한 부분 이외에

스택 영역에 사용된 각종 버퍼의 라이프 사이클을 확보해주시면 좋을 거 같고, 이후 작업에도 객체의 라이프 사이클을 shared_ptr을 쓰더라도 명확한 관리를 해주시면 좋을 거 같습니다.

listener에서 accept된 session과, disconnect 되서 유효하지 않은 session 관리도 해주시면 좋을 거 같습니다.